### PR TITLE
[DEV-22428] Inconsistent audio output: hardware volume remains low despite volume set to 100% in settings

### DIFF
--- a/lib/cordova-plugin-audiomanagement.d.ts
+++ b/lib/cordova-plugin-audiomanagement.d.ts
@@ -59,7 +59,6 @@ export declare class AudioManagementCordovaInterface {
     setAudioMode(mode: AudioMode): Promise<void>;
     getVolume(type: VolumeType): Promise<VolumeResult>;
     setVolume(type: VolumeType, volume: number, scaled?: boolean): Promise<void>;
-    getMaxVolume(type: VolumeType): Promise<MaxVolumeResult>;
     getNotificationPolicyAccessState(): Promise<NotificationPolicyAccessState>;
     hasNotificationPolicyAccess(): Promise<boolean>;
     openNotificationPolicyAccessSettings(): Promise<void>;

--- a/lib/cordova-plugin-audiomanagement.d.ts
+++ b/lib/cordova-plugin-audiomanagement.d.ts
@@ -20,13 +20,7 @@ export interface NotificationPolicyAccessState {
     isNotificationPolicyAccessGranted: boolean;
 }
 export interface VolumeResult {
-    /**
-     * Raw volume value for the target type, which is in range [0, maxVolume] where
-     * `maxVolume` is an arbitrary number provided by the OS.
-     */
-    volume: number;
-    /** Scaled percentage that will be in range [0, 100]. */
-    scaledVolume: number;
+    volumePercentage: number;
 }
 export interface MaxVolumeResult {
     maxVolume: number;

--- a/lib/cordova-plugin-audiomanagement.js
+++ b/lib/cordova-plugin-audiomanagement.js
@@ -46,9 +46,6 @@ export class AudioManagementCordovaInterface {
     setVolume(type, volume, scaled = true) {
         return invoke(`setVolume`, type, volume, scaled);
     }
-    getMaxVolume(type) {
-        return invoke(`getMaxVolume`, type);
-    }
     getNotificationPolicyAccessState() {
         return invoke(`getNotificationPolicyAccessState`);
     }

--- a/src/android/Utils.java
+++ b/src/android/Utils.java
@@ -12,44 +12,45 @@ class Utils {
     public static final int TYPE_VOICE_CALL = 4;
     public static final int TYPE_UNKNOWN = -1;
 
-    public static int getVolume(AudioManager manager, int type) {
+    public static int getVolumePercentage(AudioManager manager, int type) {
         Timber.d("getVolume() type = %s", type);
 
-        int volume = -1;
+        int volumePercentage = -1;
         int streamType = convertStreamTypeToNative(type);
 
-        if (streamType != TYPE_UNKNOWN) {
-            try {
-                volume = manager.getStreamVolume(streamType);
-                Timber.d("getVolume() loaded volume = " + volume + " for type = " + type);
-            } catch (Exception e) {
-                Timber.e("getStreamVolume() ERROR: %s", e.getMessage());
-            }
+        if (streamType == TYPE_UNKNOWN) {
+            return volumePercentage;
         }
 
-        return volume;
+        try {
+            volumePercentage = Math.round((float) manager.getStreamVolume(streamType) / manager.getStreamMaxVolume(streamType) * 100);
+            Timber.d("getVolume() loaded volume = " + volumePercentage + " for type = " + type);
+        } catch (Exception e) {
+            Timber.e("getStreamVolume() ERROR: %s", e.getMessage());
+        }
+
+        return volumePercentage;
+    }
+
+    public static void setVolumePercentage(AudioManager audioManager, int type, int volumePercentage) {
+        int streamType = convertStreamTypeToNative(type);
+        int volumeValue = Math.round((float) (audioManager.getStreamMaxVolume(streamType) * volumePercentage) / 100);
+
+        audioManager.setStreamVolume(
+            streamType,
+            volumeValue,
+            0  // No flags - silent change without UI
+        );
     }
 
     public static int convertStreamTypeToNative(final int type) {
         return switch (type) {
-            case TYPE_RING -> AudioManager.STREAM_RING;
-            case TYPE_NOTIFICATION -> AudioManager.STREAM_NOTIFICATION;
-            case TYPE_SYSTEM -> AudioManager.STREAM_SYSTEM;
-            case TYPE_MUSIC -> AudioManager.STREAM_MUSIC;
             case TYPE_VOICE_CALL -> AudioManager.STREAM_VOICE_CALL;
+            case TYPE_SYSTEM -> AudioManager.STREAM_SYSTEM;
+            case TYPE_RING -> AudioManager.STREAM_RING;
+            case TYPE_MUSIC -> AudioManager.STREAM_MUSIC;
+            case TYPE_NOTIFICATION -> AudioManager.STREAM_NOTIFICATION;
             default -> TYPE_UNKNOWN;
         };
-    }
-
-
-    public static void setVolume(AudioManager audioManager, int streamType, int volume) {
-        int maxVolume = audioManager.getStreamMaxVolume(streamType);
-        int targetVolume = Math.max(0, Math.min(volume, maxVolume));
-
-        audioManager.setStreamVolume(
-                streamType,
-                targetVolume,
-                0  // No flags - silent change without UI
-        );
     }
 }

--- a/src/android/VolumeContentObserver.java
+++ b/src/android/VolumeContentObserver.java
@@ -5,8 +5,8 @@ import static com.hrs.audiomanagement.Utils.TYPE_NOTIFICATION;
 import static com.hrs.audiomanagement.Utils.TYPE_RING;
 import static com.hrs.audiomanagement.Utils.TYPE_SYSTEM;
 import static com.hrs.audiomanagement.Utils.TYPE_VOICE_CALL;
-import static com.hrs.audiomanagement.Utils.getVolume;
-import static com.hrs.audiomanagement.Utils.setVolume;
+import static com.hrs.audiomanagement.Utils.getVolumePercentage;
+import static com.hrs.audiomanagement.Utils.setVolumePercentage;
 
 import android.database.ContentObserver;
 import android.media.AudioManager;
@@ -107,13 +107,13 @@ class VolumeContentObserver extends ContentObserver {
         syncAndNotify(null);
     }
 
-    private void syncAndNotify(@Nullable Integer volume) {
+    private void syncAndNotify(@Nullable Integer volumePercentage) {
         Integer changedVolume;
 
-        if (volume == null) {
+        if (volumePercentage == null) {
             changedVolume = detectVolumeChange();
         } else {
-            changedVolume = volume;
+            changedVolume = volumePercentage;
         }
 
         if (isApplyChangesStop || callbackContext == null || changedVolume == null || isSyncing)
@@ -138,8 +138,8 @@ class VolumeContentObserver extends ContentObserver {
             callbackContext.sendPluginResult(result);
         } catch (JSONException e) {
             PluginResult result = new PluginResult(
-                    PluginResult.Status.ERROR,
-                    "Error getting volume info: " + e.getMessage()
+                PluginResult.Status.ERROR,
+                "Error getting volume info: " + e.getMessage()
             );
             result.setKeepCallback(true);
             callbackContext.sendPluginResult(result);
@@ -147,11 +147,11 @@ class VolumeContentObserver extends ContentObserver {
     }
 
     private void changeLatestVolumeState() {
-        lastRingVolume = getVolume(audioManager, TYPE_RING);
-        lastNotificationVolume = getVolume(audioManager, TYPE_NOTIFICATION);
-        lastSystemVolume = getVolume(audioManager, TYPE_SYSTEM);
-        lastMusicVolume = getVolume(audioManager, TYPE_MUSIC);
-        lastVoiceVolume = getVolume(audioManager, TYPE_VOICE_CALL);
+        lastRingVolume = getVolumePercentage(audioManager, TYPE_RING);
+        lastNotificationVolume = getVolumePercentage(audioManager, TYPE_NOTIFICATION);
+        lastSystemVolume = getVolumePercentage(audioManager, TYPE_SYSTEM);
+        lastMusicVolume = getVolumePercentage(audioManager, TYPE_MUSIC);
+        lastVoiceVolume = getVolumePercentage(audioManager, TYPE_VOICE_CALL);
     }
 
     private void syncAllVolumes(int targetVolume) {
@@ -160,11 +160,11 @@ class VolumeContentObserver extends ContentObserver {
         try {
             Timber.d("Syncing all volumes to: %s", targetVolume);
 
-            setVolume(audioManager, TYPE_RING, targetVolume);
-            setVolume(audioManager, TYPE_NOTIFICATION, targetVolume);
-            setVolume(audioManager, TYPE_SYSTEM, targetVolume);
-            setVolume(audioManager, TYPE_MUSIC, targetVolume);
-            setVolume(audioManager, TYPE_VOICE_CALL, targetVolume);
+            setVolumePercentage(audioManager, TYPE_RING, targetVolume);
+            setVolumePercentage(audioManager, TYPE_NOTIFICATION, targetVolume);
+            setVolumePercentage(audioManager, TYPE_SYSTEM, targetVolume);
+            setVolumePercentage(audioManager, TYPE_MUSIC, targetVolume);
+            setVolumePercentage(audioManager, TYPE_VOICE_CALL, targetVolume);
 
             // Update with latest values
             changeLatestVolumeState();
@@ -186,11 +186,11 @@ class VolumeContentObserver extends ContentObserver {
     @Nullable
     private Integer detectVolumeChange() {
         // Get current volumes
-        int ring = getVolume(audioManager, TYPE_RING);
-        int notification = getVolume(audioManager, TYPE_NOTIFICATION);
-        int system = getVolume(audioManager, TYPE_SYSTEM);
-        int music = getVolume(audioManager, TYPE_MUSIC);
-        int voice = getVolume(audioManager, TYPE_VOICE_CALL);
+        int ring = getVolumePercentage(audioManager, TYPE_RING);
+        int notification = getVolumePercentage(audioManager, TYPE_NOTIFICATION);
+        int system = getVolumePercentage(audioManager, TYPE_SYSTEM);
+        int music = getVolumePercentage(audioManager, TYPE_MUSIC);
+        int voice = getVolumePercentage(audioManager, TYPE_VOICE_CALL);
 
         // Check media first
         if (music != lastMusicVolume) {
@@ -219,11 +219,11 @@ class VolumeContentObserver extends ContentObserver {
     private JSONObject makePluginMessage() throws JSONException {
         JSONObject volumeInfo = new JSONObject();
 
-        int ring = getVolume(audioManager, TYPE_RING);
-        int notification = getVolume(audioManager, TYPE_NOTIFICATION);
-        int system = getVolume(audioManager, TYPE_SYSTEM);
-        int music = getVolume(audioManager, TYPE_MUSIC);
-        int voice = getVolume(audioManager, TYPE_VOICE_CALL);
+        int ring = getVolumePercentage(audioManager, TYPE_RING);
+        int notification = getVolumePercentage(audioManager, TYPE_NOTIFICATION);
+        int system = getVolumePercentage(audioManager, TYPE_SYSTEM);
+        int music = getVolumePercentage(audioManager, TYPE_MUSIC);
+        int voice = getVolumePercentage(audioManager, TYPE_VOICE_CALL);
 
         volumeInfo.put("ring", ring);
         volumeInfo.put("notification", notification);
@@ -240,7 +240,7 @@ class VolumeContentObserver extends ContentObserver {
 
     public void requestVolumeChangeToListener() {
         // Set volume to trigger the listener
-        int targetVolume = getVolume(audioManager, TYPE_MUSIC);
+        int targetVolume = getVolumePercentage(audioManager, TYPE_MUSIC);
         syncAndNotify(targetVolume);
 
         Timber.d("Requested volume sync with TYPE_MUSIC");

--- a/src/ts/cordova-plugin-audiomanagement.ts
+++ b/src/ts/cordova-plugin-audiomanagement.ts
@@ -135,10 +135,6 @@ export class AudioManagementCordovaInterface {
 		return invoke(`setVolume`, type, volume, scaled);
 	}
 
-	public getMaxVolume(type: VolumeType): Promise<MaxVolumeResult> {
-		return invoke(`getMaxVolume`, type);
-	}
-
 	public getNotificationPolicyAccessState(): Promise<NotificationPolicyAccessState> {
 		return invoke(`getNotificationPolicyAccessState`);
 	}

--- a/www/cordova-plugin-audiomanagement.js
+++ b/www/cordova-plugin-audiomanagement.js
@@ -57,9 +57,6 @@ var AudioManagementCordovaInterface = /** @class */ (function () {
         if (scaled === void 0) { scaled = true; }
         return invoke("setVolume", type, volume, scaled);
     };
-    AudioManagementCordovaInterface.prototype.getMaxVolume = function (type) {
-        return invoke("getMaxVolume", type);
-    };
     AudioManagementCordovaInterface.prototype.getNotificationPolicyAccessState = function () {
         return invoke("getNotificationPolicyAccessState");
     };


### PR DESCRIPTION
# Description

Previously, the volume set was based on a scale depending if is Samsung tablet or not. This was provoking inconsistencies in the different stream sources (each stream has a different max value).

Now, this PR modified that to work specifically with percentages and set a value based on each stream source.

## Caveats

To set the audio value we use: `AudioManager#setStreamVolume(int type, int index, int flag)`

The second parameter (`index`) is an _integer_, making work with percentages a bit problematic because instead work with exact values, we need to set _rounded values_. This is the line in responsible of that:

```java
Math.round((float) (audioManager.getStreamMaxVolume(streamType) * volumePercentage) / 100);
```

What is expected (and depending on the device could be noticeable) is even if you set the volume using the hardware keys or app UI it might go a bit higher or lower (depending on the decimals). This was a problem meanwhile I was working on this change, because instead the previous code with the `Math.round`, I had:

```java
(int)((double) (audioManager.getStreamMaxVolume(streamType) * volumePercentage) / 100);
```

The code above was always rounding the value to using an extreme _floor function_, i.e. if the value was `3.9` it was giving a `3` making the volume UI going wildly crazy. With the `Math.round` we are getting a better approximation of the value.

The conclusion is, to set the audio we need to round the value, the worst scenario is a value and a half decimal (i.e `3.5`) making the volume in the device UI go a bit higher after a while.

### Representation

> [!IMPORTANT]
> This is a manually representation of what is described in [Caveats'](#caveats) section.

https://github.com/user-attachments/assets/5b95eaaf-c6b2-4e12-a7a4-3a121073ceba

# Tickets

- [DEV-22428](https://healthrecoverysolutions.atlassian.net/browse/DEV-22428)
- This might resolve [DEV-22442](https://healthrecoverysolutions.atlassian.net/browse/DEV-22442)