### PR TITLE
DEV-22696: Remove `RING` source channel to don't modify Do Not Disturb mode

### DIFF
--- a/src/android/VolumeContentObserver.java
+++ b/src/android/VolumeContentObserver.java
@@ -160,7 +160,8 @@ class VolumeContentObserver extends ContentObserver {
         try {
             Timber.d("Syncing all volumes to: %s", targetVolume);
 
-            setVolumePercentage(audioManager, TYPE_RING, targetVolume);
+            // The 10 value is required to DON'T impact Do Not Disturb mode
+            setVolumePercentage(audioManager, TYPE_RING, Math.max(targetVolume, 10));
             setVolumePercentage(audioManager, TYPE_NOTIFICATION, targetVolume);
             setVolumePercentage(audioManager, TYPE_SYSTEM, targetVolume);
             setVolumePercentage(audioManager, TYPE_MUSIC, targetVolume);


### PR DESCRIPTION
# Description

In A9+ tablets, reduce the volume to 0 modify the `RING` volume channel. This has an impact in `Do Not Disturb` (DND) mode and for this, the app needs a special permission.

The workaround is to keep the volume for the `RING` between `[10, 100]`.